### PR TITLE
Add namespace to JsonConverter class

### DIFF
--- a/Runtime/Scripts/Utils/JsonConverter.cs
+++ b/Runtime/Scripts/Utils/JsonConverter.cs
@@ -1,33 +1,36 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-public static class JsonConverter
+namespace Geeklab.AudiencelabSDK
 {
-    public static string ConvertToJson(object data)
+    public static class JsonConverter
     {
-        if (data is string)
+        public static string ConvertToJson(object data)
         {
-            return (string)data;
-        }
-        
-        if (data is string jsonString)
-        {
-            try
-            {
-                var parsedObject = JsonConvert.DeserializeObject(jsonString);
-                return JsonConvert.SerializeObject(parsedObject);
-            }
-            catch (JsonException)
+            if (data is string)
             {
                 return (string)data;
             }
-        }
 
-        if (data is List<object> || data is List<string> || data is Dictionary<string, string>)
-        {
-            return JsonConvert.SerializeObject(data);
+            if (data is string jsonString)
+            {
+                try
+                {
+                    var parsedObject = JsonConvert.DeserializeObject(jsonString);
+                    return JsonConvert.SerializeObject(parsedObject);
+                }
+                catch (JsonException)
+                {
+                    return (string)data;
+                }
+            }
+
+            if (data is List<object> || data is List<string> || data is Dictionary<string, string>)
+            {
+                return JsonConvert.SerializeObject(data);
+            }
+
+            return (string)data;
         }
-        
-        return (string)data;
     }
 }


### PR DESCRIPTION
I use the Newtonsoft Json SDK in Unity, and this SDK conflicts with their JsonConverter class. To avoid this conflict, I have wrapped up the JsonConverter class in the Geeklab.AudiencelabSDK namespace.