### PR TITLE
V0.951

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
-## [0.9.0] - 2024-07-24
+## [0.9.51] - 2024-10-29
 
-#### Initial release
+### Changed
+
+- Added support for Resolution Scaling
+- Added UTC offset and retentionDay to payload, to offer better granuality on creative level ROAS metrics.
+- Some minor clean up
+
+## [0.9.5] - 2024-10-29
+
+### Changed
+
+- Modified the ad payload to include revenue and currency
+- Modified the value data types to [double] from [int]
+- Added the data types to #readme tutorial
 
 ## [0.9.1] - 2024-09-26
 
@@ -30,10 +42,6 @@
 - Optimized the SDK for performance.
 - Improved the documentation.
 
-## [0.9.5] - 2024-10-29
+## [0.9.0] - 2024-07-24
 
-### Changed
-
-- Modified the ad payload to include revenue and currency
-- Modified the value data types to [double] from [int]
-- Added the data types to #readme tutorial
+#### Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [0.9.51] - 2024-10-29
+## [0.9.51] - 2024-11-27
 
 ### Changed
 
 - Added support for Resolution Scaling
-- Added UTC offset and retentionDay to payload, to offer better granuality on creative level ROAS metrics.
+- Added UTC offset and retention day tracking to payload for more granular creative-level ROAS metrics and improved UTC-based analytics
 - Some minor clean up
 
 ## [0.9.5] - 2024-10-29

--- a/Editor/SDKSettingsEditor.cs.meta
+++ b/Editor/SDKSettingsEditor.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: b48a0765d69345349edbb5539bba6f42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/SDKSettingsModelEditor.cs.meta
+++ b/Editor/SDKSettingsModelEditor.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 110735bc5ee84e8b986946df7c6116b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/Android/InstalledFonts.java.meta
+++ b/Plugins/Android/InstalledFonts.java.meta
@@ -1,2 +1,32 @@
 fileFormatVersion: 2
 guid: 97ca9db45c57493692ea8381c457be23
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/iOS/DeviceGeneration.m.meta
+++ b/Plugins/iOS/DeviceGeneration.m.meta
@@ -1,2 +1,37 @@
 fileFormatVersion: 2
 guid: 2cd8080d34a343fd987627ef3c181ffd
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/iOS/InstalledFonts.m.meta
+++ b/Plugins/iOS/InstalledFonts.m.meta
@@ -1,2 +1,37 @@
 fileFormatVersion: 2
 guid: 0074f0554cb34d4da528aa2eaa59197b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/iOS/NativeResolution.m
+++ b/Plugins/iOS/NativeResolution.m
@@ -1,0 +1,27 @@
+#import <UIKit/UIKit.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *_GetNativeScreenWidth() {
+    CGRect screenBounds = [UIScreen mainScreen].bounds;
+    CGFloat scale = [UIScreen mainScreen].scale;
+    NSString *widthString = [NSString stringWithFormat:@"%f", screenBounds.size.width * scale];
+    char *returnValue = (char *)malloc(sizeof(char) * (widthString.length + 1));
+    strcpy(returnValue, [widthString UTF8String]);
+    return returnValue;
+}
+
+char *_GetNativeScreenHeight() {
+    CGRect screenBounds = [UIScreen mainScreen].bounds;
+    CGFloat scale = [UIScreen mainScreen].scale;
+    NSString *heightString = [NSString stringWithFormat:@"%f", screenBounds.size.height * scale];
+    char *returnValue = (char *)malloc(sizeof(char) * (heightString.length + 1));
+    strcpy(returnValue, [heightString UTF8String]);
+    return returnValue;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/Plugins/iOS/NativeResolution.m.meta
+++ b/Plugins/iOS/NativeResolution.m.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: dd5a180025ed4c3ba7601e520a75b3f1
+guid: 9750ffe0c15ab49349491aa8311a920e
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -12,11 +12,6 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Android: Android
-    second:
-      enabled: 1
-      settings: {}
-  - first:
       Any: 
     second:
       enabled: 0
@@ -27,6 +22,16 @@ PluginImporter:
       enabled: 0
       settings:
         DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Runtime/Scripts/GeeklabSDK.cs.meta
+++ b/Runtime/Scripts/GeeklabSDK.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: c9d860d76751f0945b7a92b462797639
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Handlers/DeepLinkHandler.cs.meta
+++ b/Runtime/Scripts/Handlers/DeepLinkHandler.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 82742fc857e3bbd4db897f63bc9fa450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Handlers/DeviceInfoHandler.cs
+++ b/Runtime/Scripts/Handlers/DeviceInfoHandler.cs
@@ -104,13 +104,34 @@ namespace Geeklab.AudiencelabSDK
     [DllImport("__Internal")]
     static extern IntPtr _GetNativeScreenHeight();
 
-    string nativeWidthString = Marshal.PtrToStringAnsi(_GetNativeScreenWidth());
-    string nativeHeightString = Marshal.PtrToStringAnsi(_GetNativeScreenHeight());
+     try
+    {
+        string nativeWidthString = Marshal.PtrToStringAnsi(_GetNativeScreenWidth());
+        string nativeHeightString = Marshal.PtrToStringAnsi(_GetNativeScreenHeight());
 
-    nativeWidth = Mathf.RoundToInt(float.Parse(nativeWidthString));
-    nativeHeight = Mathf.RoundToInt(float.Parse(nativeHeightString));
+        if (!string.IsNullOrEmpty(nativeWidthString) && !string.IsNullOrEmpty(nativeHeightString) &&
+            float.TryParse(nativeWidthString, out float width) && 
+            float.TryParse(nativeHeightString, out float height))
+        {
+            nativeWidth = Mathf.RoundToInt(width);
+            nativeHeight = Mathf.RoundToInt(height);
+        }
+        else
+        {
+            // Fallback to Screen resolution if parsing fails
+            nativeWidth = Screen.currentResolution.width;
+            nativeHeight = Screen.currentResolution.height;
+            Debug.LogWarning("Failed to get native resolution, using Screen.currentResolution as fallback");
+        }
+    }
+    catch (Exception e)
+    {
+        // Fallback to Screen resolution if any error occurs
+        nativeWidth = Screen.currentResolution.width;
+        nativeHeight = Screen.currentResolution.height;
+        Debug.LogError($"Error getting native resolution: {e.Message}. Using Screen.currentResolution as fallback");
+    }
 
-    Debug.LogWarning($"Width: {nativeWidth}, Height: {nativeHeight}");
 #elif UNITY_ANDROID && !UNITY_EDITOR
     // Use Android-specific methods for native resolution
     using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))

--- a/Runtime/Scripts/Handlers/DeviceInfoHandler.cs.meta
+++ b/Runtime/Scripts/Handlers/DeviceInfoHandler.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 57f0956eea2e33a43ab001b76c97c579
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Handlers/TokenHandler.cs
+++ b/Runtime/Scripts/Handlers/TokenHandler.cs
@@ -11,7 +11,6 @@ namespace Geeklab.AudiencelabSDK
     {
         private const string TOKEN_KEY = "GeeklabCreativeToken";
         private static string creativeToken = "";
-        private static string lastCheckedToken = "";
 
         
         private void Start()

--- a/Runtime/Scripts/Handlers/TokenHandler.cs.meta
+++ b/Runtime/Scripts/Handlers/TokenHandler.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: ecfc4beb560436947ab283f429d32dd6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Managers/AndroidManager.cs.meta
+++ b/Runtime/Scripts/Managers/AndroidManager.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 4702ad10dddff4a4f897135b51cc0b8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Managers/SDKSettingsManager.cs.meta
+++ b/Runtime/Scripts/Managers/SDKSettingsManager.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: efa8e982a89d401d97e42878e3cfe535
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Managers/ServiceManager.cs.meta
+++ b/Runtime/Scripts/Managers/ServiceManager.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 3596e365da0d4820bf49a592bb3a6518
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Managers/WebRequestManager.cs
+++ b/Runtime/Scripts/Managers/WebRequestManager.cs
@@ -103,8 +103,10 @@ namespace Geeklab.AudiencelabSDK
                 gpu_vendor = SystemInfo.graphicsDeviceVendor,
                 gpu_version = SystemInfo.graphicsDeviceVersion,
                 gpu_content =  deviceInfo.GpuContent,
-                window_height = deviceInfo.Height,
-                window_width = deviceInfo.Width,
+                window_height = deviceInfo.NativeHeight,
+                legacy_height = deviceInfo.Height,
+                window_width = deviceInfo.NativeWidth,
+                legacy_width = deviceInfo.Width,
                 installed_fonts = deviceInfo.InstalledFonts,
                 low_battery_level = deviceInfo.LowPower,
                 os_system = deviceInfo.OsVersion,
@@ -120,9 +122,22 @@ namespace Geeklab.AudiencelabSDK
             };
             
             var json = JsonConvert.SerializeObject(postDataFull);
+            Debug.Log(json);
+            SendRequest(ApiEndpointsModel.FETCH_TOKEN, json, onSuccess, onError);
 
-            SendRequest(ApiEndpointsModel.FETCH_TOKEN, json, onSuccess, onError, UnityWebRequest.kHttpVerbPOST);
+        }
 
+        private string GetUtcOffset()
+        {
+            // Get current UTC offset
+            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
+
+            // Format as "+HH:mm" or "-HH:mm"
+            string formattedOffset = offset >= TimeSpan.Zero
+                ? $"+{offset.Hours:D2}:{offset.Minutes:D2}"
+                : $"-{Math.Abs(offset.Hours):D2}:{Math.Abs(offset.Minutes):D2}";
+
+            return formattedOffset;
         }
 
         
@@ -134,6 +149,18 @@ namespace Geeklab.AudiencelabSDK
 
             var deviceInfo = DeviceInfoHandler.GetDeviceInfo();
 
+            // Get UTC offset
+
+            var utcOffset = GetUtcOffset();
+
+            string retentionDay;
+            if (PlayerPrefs.HasKey("retentionDay") && PlayerPrefs.GetString("retentionDay") != "") {
+                retentionDay = PlayerPrefs.GetString("retentionDay");
+            } else {
+                retentionDay = "0";
+            }
+
+
             var postData = new
             {
                 type = type,
@@ -142,6 +169,8 @@ namespace Geeklab.AudiencelabSDK
                 device_name = deviceInfo.DeviceName,
                 device_model = SystemInfo.deviceModel,
                 os_system = deviceInfo.OsVersion,
+                utc_offset = utcOffset,
+                retention_day = retentionDay,
                 payload = data
             };
             var json = JsonConvert.SerializeObject(postData);

--- a/Runtime/Scripts/Managers/WebRequestManager.cs
+++ b/Runtime/Scripts/Managers/WebRequestManager.cs
@@ -153,12 +153,10 @@ namespace Geeklab.AudiencelabSDK
 
             var utcOffset = GetUtcOffset();
 
-            string retentionDay;
-            if (PlayerPrefs.HasKey("retentionDay") && PlayerPrefs.GetString("retentionDay") != "") {
-                retentionDay = PlayerPrefs.GetString("retentionDay");
-            } else {
-                retentionDay = "0";
-            }
+            string retentionDay = "";
+            if (PlayerPrefs.HasKey("retentionDay")) {
+                retentionDay = PlayerPrefs.GetInt("retentionDay").ToString();
+            } 
 
 
             var postData = new

--- a/Runtime/Scripts/Managers/WebRequestManager.cs.meta
+++ b/Runtime/Scripts/Managers/WebRequestManager.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 2378193c6f9246c585969e0134c95f64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Metrics/AdMetrics.cs.meta
+++ b/Runtime/Scripts/Metrics/AdMetrics.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 287fada9580339d47a27b008dae63097
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Metrics/PurchaseMetrics.cs.meta
+++ b/Runtime/Scripts/Metrics/PurchaseMetrics.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 6ad2d58505acdaf42951514409b0c0f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Metrics/UserMetrics.cs
+++ b/Runtime/Scripts/Metrics/UserMetrics.cs
@@ -8,9 +8,7 @@ namespace Geeklab.AudiencelabSDK
 {
     public class UserMetrics : MonoBehaviour
     {
-        private static int daysLoggedIn;
         private static float sessionTime;
-        private static int levelPassed;
         private static int timesTriedToFetchToken = 0;
 
         
@@ -34,9 +32,7 @@ namespace Geeklab.AudiencelabSDK
             else
             {
                 Debug.Log("Creative token found");
-                daysLoggedIn = 0;
                 sessionTime = 0.0f;
-                levelPassed = 0;
                 if (PlayerPrefs.GetString("firstLogin") == "")
                 {
                     InitializeFirstLogin(); 

--- a/Runtime/Scripts/Metrics/UserMetrics.cs.meta
+++ b/Runtime/Scripts/Metrics/UserMetrics.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 3b091cd9407560546a93e12f37e5d186
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/ApiEndpointsModel.cs.meta
+++ b/Runtime/Scripts/Models/ApiEndpointsModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 8174054459c54064a6148368f45806fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/DeviceInfoModel.cs
+++ b/Runtime/Scripts/Models/DeviceInfoModel.cs
@@ -8,6 +8,8 @@ namespace Geeklab.AudiencelabSDK
         public float Dpi;
         public int Width;
         public int Height;
+        public int NativeWidth;
+        public int NativeHeight;
         public bool LowPower;
         public string Timezone;
         public string OsVersion;

--- a/Runtime/Scripts/Models/DeviceInfoModel.cs.meta
+++ b/Runtime/Scripts/Models/DeviceInfoModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 6c54c0564745fc241a683f859826e475
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/MetricsModel.cs.meta
+++ b/Runtime/Scripts/Models/MetricsModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 6a95b1e72b5d0e44b8049e3cce8f9a44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/PostDataModel.cs.meta
+++ b/Runtime/Scripts/Models/PostDataModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 9e59825b2f17451aa93007606a74d3c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/SDKSettingsModel.cs.meta
+++ b/Runtime/Scripts/Models/SDKSettingsModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 405e8766ee134699a544401140f8b657
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/SDKTokenModel.cs.meta
+++ b/Runtime/Scripts/Models/SDKTokenModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 27948ea44af24a798bd94bd2c8159fbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Models/TokenResponseModel.cs.meta
+++ b/Runtime/Scripts/Models/TokenResponseModel.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: eeef6e0258db453f9f56c93b43496fe9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Utils/DisableIfSDKDisabled.cs.meta
+++ b/Runtime/Scripts/Utils/DisableIfSDKDisabled.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 24dd117e7e174ac88d14c8a21cf805df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Utils/FieldGroup.cs.meta
+++ b/Runtime/Scripts/Utils/FieldGroup.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: d0629b5b51fa469d9d24cf213837b92d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Utils/HideInFieldGroupAttribute.cs.meta
+++ b/Runtime/Scripts/Utils/HideInFieldGroupAttribute.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 69a7455f29084665821f813cd91464b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Utils/JsonConverter.cs.meta
+++ b/Runtime/Scripts/Utils/JsonConverter.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 9fdd6b96edfc4341bd5ebb1146085528
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Utils/MetricToggle.cs.meta
+++ b/Runtime/Scripts/Utils/MetricToggle.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 0b2bddf2adb854740a863d9f258a3983
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/GeeklabSDK_WebRequestTests.cs.meta
+++ b/Tests/Runtime/GeeklabSDK_WebRequestTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 96ade24a169a46a4afdc4e5a27319987
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.geeklab.audiencelab-sdk",
   "displayName": "Audiencelab SDK",
-  "version": "0.9.5",
+  "version": "0.9.51",
   "unity": "2023.1",
   "description": "Audiencelab SDK is a set of utilities for development in Unity. It includes tools for handling deep links, collecting metrics, managing network requests, and much more.",
   "keywords": [


### PR DESCRIPTION
### Add support for resolution scaling on iOS and improve analytics payload granularity

#### Resolution Scaling on iOS
- Added support for resolution scaling on iOS to handle cases where manual device resolution scaling previously broke some pipelines.
- Implemented a new native plugin to retrieve accurate screen dimensions:
```objc
  #import <UIKit/UIKit.h>

  #ifdef __cplusplus
  extern "C" {
  #endif

  char *_GetNativeScreenWidth() {
      CGRect screenBounds = [UIScreen mainScreen].bounds;
      CGFloat scale = [UIScreen mainScreen].scale;
      NSString *widthString = [NSString stringWithFormat:@"%f", screenBounds.size.width * scale];
      char *returnValue = (char *)malloc(sizeof(char) * (widthString.length + 1));
      strcpy(returnValue, [widthString UTF8String]);
      return returnValue;
  }

  char *_GetNativeScreenHeight() {
      CGRect screenBounds = [UIScreen mainScreen].bounds;
      CGFloat scale = [UIScreen mainScreen].scale;
      NSString *heightString = [NSString stringWithFormat:@"%f", screenBounds.size.height * scale];
      char *returnValue = (char *)malloc(sizeof(char) * (heightString.length + 1));
      strcpy(returnValue, [heightString UTF8String]);
      return returnValue;
  }

  #ifdef __cplusplus
  }
  #endif
  ```

- Added error-handling logic to ensure fallback to Screen.currentResolution in cases of parsing failures or exceptions:

```csharp
try {
    string nativeWidthString = Marshal.PtrToStringAnsi(_GetNativeScreenWidth());
    string nativeHeightString = Marshal.PtrToStringAnsi(_GetNativeScreenHeight());

    if (!string.IsNullOrEmpty(nativeWidthString) && !string.IsNullOrEmpty(nativeHeightString) &&
        float.TryParse(nativeWidthString, out float width) &&
        float.TryParse(nativeHeightString, out float height)) {
        nativeWidth = Mathf.RoundToInt(width);
        nativeHeight = Mathf.RoundToInt(height);
    } else {
        nativeWidth = Screen.currentResolution.width;
        nativeHeight = Screen.currentResolution.height;
        Debug.LogWarning("Failed to get native resolution, using Screen.currentResolution as fallback");
    }
} catch (Exception e) {
    nativeWidth = Screen.currentResolution.width;
    nativeHeight = Screen.currentResolution.height;
    Debug.LogError($"Error getting native resolution: {e.Message}. Using Screen.currentResolution as fallback");
}
```


Improved Analytics Payload

- Added UTC offset and retentionDay to analytics payload for better data granularity while maintaining user privacy.
- UTC Offset: Retrieves the current UTC offset in +HH:mm or -HH:mm format.

```csharp
private string GetUtcOffset() {
    TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
    string formattedOffset = offset >= TimeSpan.Zero
        ? $"+{offset.Hours:D2}:{offset.Minutes:D2}"
        : $"-{Math.Abs(offset.Hours):D2}:{Math.Abs(offset.Minutes):D2}";
    return formattedOffset;
}
```


Retention Day: Accesses a locally stored integer value using PlayerPrefs:

```csharp
string retentionDay = "";
if (PlayerPrefs.HasKey("retentionDay")) {
    retentionDay = PlayerPrefs.GetInt("retentionDay").ToString();
}
```



This update ensures compatibility with iOS resolution scaling while improving analytics capabilities for better insights.