### PR TITLE
Missing meta file version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2026-02-23
+
+### Fixed
+
+- Added missing `.meta` file for `Editor/geeklab.audiencelab-sdk.Editor.asmdef`
+
 ## [1.1.5] - 2026-02-23
 
 ### Fixed

--- a/Editor/geeklab.audiencelab-sdk.Editor.asmdef.meta
+++ b/Editor/geeklab.audiencelab-sdk.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88319fdc2e4b4e379fb57aacd78817e3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.geeklab.audiencelab-sdk",
 	"displayName": "Audiencelab SDK",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"unity": "2023.1",
 	"description": "AudienceLab is a mobile attribution SDK for Unity that tracks user acquisition, ad revenue, in-app purchases, custom events and session tracking.",
 	"keywords": [


### PR DESCRIPTION
Create missing `.meta` file and increment version to 1.1.6 to fix a previous pull request issue.

---
[Slack Thread](https://geeklab-app.slack.com/archives/D092R7L603X/p1771870478484689?thread_ts=1771870478.484689&cid=D092R7L603X)

<p><a href="https://cursor.com/agents/bc-30e3c611-3839-5dd8-a9ed-7147177287e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e3c611-3839-5dd8-a9ed-7147177287e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Unity asset `.meta` file and bumps the package version; no runtime logic changes, so risk is minimal aside from packaging/import metadata.
> 
> **Overview**
> Bumps the Unity package version to `1.1.6` and updates the changelog to document the fix.
> 
> Adds the missing Unity `.meta` file for `Editor/geeklab.audiencelab-sdk.Editor.asmdef`, ensuring the Editor assembly definition is properly tracked/imported in Unity and in packaged releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd413c90af599dd371a6908ef7ab8922ec3d1ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->